### PR TITLE
Wrong configname on windows. 

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,28 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <DBN-PSQL>
+      <case-options enabled="false">
+        <option name="KEYWORD_CASE" value="lower" />
+        <option name="FUNCTION_CASE" value="lower" />
+        <option name="PARAMETER_CASE" value="lower" />
+        <option name="DATATYPE_CASE" value="lower" />
+        <option name="OBJECT_CASE" value="preserve" />
+      </case-options>
+      <formatting-settings enabled="false" />
+    </DBN-PSQL>
+    <DBN-SQL>
+      <case-options enabled="false">
+        <option name="KEYWORD_CASE" value="lower" />
+        <option name="FUNCTION_CASE" value="lower" />
+        <option name="PARAMETER_CASE" value="lower" />
+        <option name="DATATYPE_CASE" value="lower" />
+        <option name="OBJECT_CASE" value="preserve" />
+      </case-options>
+      <formatting-settings enabled="false">
+        <option name="STATEMENT_SPACING" value="one_line" />
+        <option name="CLAUSE_CHOP_DOWN" value="chop_down_if_statement_long" />
+        <option name="ITERATION_ELEMENTS_WRAPPING" value="chop_down_if_not_single" />
+      </formatting-settings>
+    </DBN-SQL>
+  </code_scheme>
+</component>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile default="true" name="Default" enabled="true" />
+    </annotationProcessing>
     <bytecodeTargetLevel>
       <module name="xp-gradle-plugin-sitemerge_main" target="1.7" />
       <module name="xp-gradle-plugin-sitemerge_test" target="1.7" />

--- a/.idea/modules/xp-gradle-plugin-sitemerge_test.iml
+++ b/.idea/modules/xp-gradle-plugin-sitemerge_test.iml
@@ -23,17 +23,6 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.gradle/wrapper/dists/gradle-4.3.1-all/97nfwr7im082t7xwc6bkwfrg9/gradle-4.3.1/lib/gradle-installation-beacon-4.3.1.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="file://$USER_HOME$/.gradle/wrapper/dists/gradle-4.3.1-all/97nfwr7im082t7xwc6bkwfrg9/gradle-4.3.1/src/installation-beacon" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
           <root url="jar://$USER_HOME$/.gradle/caches/4.3.1/generated-gradle-jars/gradle-api-4.3.1.jar!/" />
         </CLASSES>
         <JAVADOC />
@@ -117,6 +106,17 @@
         </CLASSES>
         <JAVADOC />
         <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.gradle/wrapper/dists/gradle-4.3.1-all/97nfwr7im082t7xwc6bkwfrg9/gradle-4.3.1/lib/gradle-installation-beacon-4.3.1.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="file://$USER_HOME$/.gradle/wrapper/dists/gradle-4.3.1-all/97nfwr7im082t7xwc6bkwfrg9/gradle-4.3.1/src/installation-beacon" />
+        </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">

--- a/src/main/groovy/no/tine/gradle/xp/SiteMergeModule.groovy
+++ b/src/main/groovy/no/tine/gradle/xp/SiteMergeModule.groovy
@@ -82,13 +82,17 @@ class SiteMergeModule implements SiteMergeConstants {
 
 		GPathResult siteLib = new XmlSlurper().parse(file)
 
-		def configName = file.toString().tokenize('/').last()[0..-5]
+		def configName = getConfigName(file, File.separator)
 
 		removeOldMerges(original)
 
 		appendToConfig(siteLib, original, configName)
 
 		appendXData(siteLib, original, configName)
+	}
+
+	static String getConfigName(File file, String separator) {
+		return file.toString().tokenize(separator).last()[0..-5]
 	}
 
 	/**

--- a/src/test/groovy/no/tine/gradle/xp/SiteMergeModuleTest.groovy
+++ b/src/test/groovy/no/tine/gradle/xp/SiteMergeModuleTest.groovy
@@ -37,4 +37,26 @@ class SiteMergeModuleTest extends Specification {
 		originalFile[0].children.size() == 3
 	}
 
+	def "Get config name on windows"() {
+		setup:
+		File file = new File("C:\\temp\\site\\site.xml")
+
+		when:
+		String name = SiteMergeModule.getConfigName(file, "\\")
+
+		then:
+		name == "site"
+	}
+
+	def "Get config name on linux"() {
+		setup:
+		File file = new File("/temp/test/site/site.xml")
+
+		when:
+		String name = SiteMergeModule.getConfigName(file, "/")
+
+		then:
+		name == "site"
+	}
+
 }


### PR DESCRIPTION
Changed from '/' to File.seprator when "getting" configname. Added also tests. This closes #7. 